### PR TITLE
_mousetrap does not exist in this scope, should be this._mousetrap

### DIFF
--- a/lib/mixin/Mousetrap.js
+++ b/lib/mixin/Mousetrap.js
@@ -62,7 +62,7 @@ var MousetrapMixin = {
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
     this._unbind();
     this._mousetrap = nextProps.mousetrap;
-    if (!_mousetrap) {
+    if (!this._mousetrap) {
       if (typeof this.getMousetrap === 'function') {
         this._mousetrap = this.getMousetrap();
       } else {


### PR DESCRIPTION
It appears that there is a typo on lib/mixin/Mousetrap.js, function componentWillReceiveProps, and it is raising errors when executed under strict mode.
